### PR TITLE
Add require extra section in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
     "psr-4": {
       "KayStrobach\\Migrations\\": "Classes/"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "migrations"
+    }
   }
 }


### PR DESCRIPTION
It seems that in the next TYPO3 version the composer section "extra" will be more important, so I add it.

LINK: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra