### PR TITLE
Prevent redirect in BE user authentication

### DIFF
--- a/Classes/Migration/AbstractDataHandlerMigration.php
+++ b/Classes/Migration/AbstractDataHandlerMigration.php
@@ -104,7 +104,7 @@ abstract class AbstractDataHandlerMigration extends AbstractMigration
 
         $this->getMigrationCoordinator()->setCurrentVersion($version);
 
-        Bootstrap::initializeBackendAuthentication();
+        Bootstrap::initializeBackendAuthentication(true);
     }
 
 
@@ -117,7 +117,7 @@ abstract class AbstractDataHandlerMigration extends AbstractMigration
 
     public function preDown(Schema $schema) : void
     {
-        Bootstrap::initializeBackendAuthentication();
+        Bootstrap::initializeBackendAuthentication(true);
     }
 
     /**


### PR DESCRIPTION
This prevents a redirect to the TYPO3 login page when no BE user is logged in. This redirect does not seem to always occur, but in some situations, it is performed, and a later migration might fail then due to an error because headers were already sent.