### PR TITLE
Avoid PHP 8 warning

### DIFF
--- a/Classes/Service/DoctrineService.php
+++ b/Classes/Service/DoctrineService.php
@@ -133,7 +133,7 @@ class DoctrineService implements LoggerAwareInterface
     {
         $autoloadComposerDefinition = $package->getValueFromComposerManifest('autoload');
 
-        if ($autoloadComposerDefinition->{'psr-4'} instanceof \stdClass) {
+        if (($autoloadComposerDefinition->{'psr-4'} ?? null) instanceof \stdClass) {
             $psr4Namespaces = get_object_vars($autoloadComposerDefinition->{'psr-4'});
             foreach ($psr4Namespaces as $namespace => $dir) {
                 if (strpos($namespace, '\\Migrations\\')) {


### PR DESCRIPTION
Avoid PHP 8 warning "Warning: Attempt to read property "psr-4" on null" when is no PSR-4 autoload information can be loaded for an extension.

This could be the case, if an extension has no PHP files at, like https://github.com/TYPO3/typo3/blob/11.5/typo3/sysext/filemetadata/composer.json