### PR TITLE
Revert "[TASK] Run composer normalize in pipeline"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
         command:
           - "cs:check"
           - "php:static"
-          - "composer:normalize"
 
   code-quality:
     name: "Code quality checks (single PHP version)"

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
 		}
 	},
 	"scripts": {
-		"composer:normalize": "composer normalize --no-check-lock --dry-run",
 		"cs:check": "php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix --config .php-cs-fixer.php -v --diff",
 		"php:static": "phpstan analyze --no-interaction"


### PR DESCRIPTION
The task is already run in the "single PHP version" pipeline.

This reverts commit 052f10a73abe0a872f81cf76bf37201b5007a07c.